### PR TITLE
make srfc37 optional and disabled by default

### DIFF
--- a/packages/sdk/jest.config.js
+++ b/packages/sdk/jest.config.js
@@ -23,6 +23,8 @@ export default {
   ],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
+    '^@mosaic/abl$': '<rootDir>/src/__mocks__/@mosaic/abl.ts',
+    '^@mosaic/ebalts$': '<rootDir>/src/__mocks__/@mosaic/ebalts.ts',
   },
   moduleFileExtensions: ['ts', 'js', 'json'],
   setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts'],

--- a/packages/sdk/src/__mocks__/@mosaic/abl.ts
+++ b/packages/sdk/src/__mocks__/@mosaic/abl.ts
@@ -1,0 +1,80 @@
+import type { Address, Rpc, SolanaRpcApi } from 'gill';
+
+export const Mode = { Allow: 1, Block: 2 } as const;
+
+export async function findListConfigPda(): Promise<[string, string]> {
+  return ['ListCfgMock1111111111111111111111111111111', 'bump'];
+}
+
+// Minimal mock: return the shape that sdk/src/abl/list.ts expects
+export async function fetchListConfig(
+  _rpc: Rpc<SolanaRpcApi>,
+  listConfig: Address
+): Promise<{
+  address: Address;
+  data: { mode: number; seed: Address; authority: Address };
+}> {
+  return {
+    address: listConfig,
+    data: {
+      mode: Mode.Block,
+      seed: listConfig,
+      authority: listConfig,
+    },
+  };
+}
+
+// Very lightweight decoders used by list.ts
+export function getABWalletDecoder() {
+  return {
+    decode: (_data: Uint8Array) => ({
+      wallet: 'WalletMock11111111111111111111111111111111' as Address,
+    }),
+  };
+}
+
+export function getListConfigDecoder() {
+  return {
+    decode: (_data: Uint8Array) => ({
+      mode: Mode.Block,
+      seed: 'SeedMock111111111111111111111111111111111' as Address,
+      authority: 'AuthMock11111111111111111111111111111111' as Address,
+    }),
+  };
+}
+
+export async function findABWalletPda(): Promise<[string, string]> {
+  return ['ABWalletMock111111111111111111111111111111', 'bump'];
+}
+
+export function getAddWalletToListInstruction(): any {
+  return {
+    programAddress: 'AblProgramMockAdd',
+    accounts: [],
+    data: new Uint8Array([2]),
+  };
+}
+
+export function getRemoveWalletFromListInstruction(): any {
+  return {
+    programAddress: 'AblProgramMockRemove',
+    accounts: [],
+    data: new Uint8Array([3]),
+  };
+}
+
+export function getInitializeListConfigInstruction() {
+  return {
+    programAddress: 'AblProgramMockInitialize',
+    accounts: [],
+    data: new Uint8Array([1]),
+  };
+}
+
+export function getSetExtraMetasThawInstruction() {
+  return {
+    programAddress: 'AblProgramMockSetExtraMetasThaw',
+    accounts: [],
+    data: new Uint8Array([1]),
+  };
+}

--- a/packages/sdk/src/__mocks__/@mosaic/ebalts.ts
+++ b/packages/sdk/src/__mocks__/@mosaic/ebalts.ts
@@ -1,0 +1,104 @@
+import type {
+  SetGatingProgramInstruction,
+  TogglePermissionlessInstructionsInstruction,
+} from '@mosaic/ebalts';
+import { AccountRole, type Address, type TransactionSigner } from 'gill';
+
+export async function findMintConfigPda(): Promise<[string, string]> {
+  return ['MintCfgMock1111111111111111111111111111111', 'bump'];
+}
+export async function getCreateConfigInstruction(): Promise<any> {
+  return { __mock: 'create-config' };
+}
+export async function findThawExtraMetasAccountPda(): Promise<
+  [string, string]
+> {
+  return ['ThawExtraMock111111111111111111111111111111', 'bump'];
+}
+export async function findFreezeExtraMetasAccountPda(): Promise<
+  [string, string]
+> {
+  return ['FreezeExtraMock11111111111111111111111111111', 'bump'];
+}
+
+// EBALTS program address (matches utils.ts)
+const EBALTS_PROGRAM_ID = '81H44JYqk1p8RUks7pNJjhQG4Pj8FcaJeTUxZKN3JfLc';
+
+export function getFreezeInstruction(
+  _args: any,
+  ctx: { programAddress: string }
+) {
+  return {
+    programAddress: ctx.programAddress ?? EBALTS_PROGRAM_ID,
+    accounts: [],
+    data: new Uint8Array([10]),
+  };
+}
+
+export function createThawPermissionlessInstructionWithExtraMetas(
+  authority: TransactionSigner<string>,
+  tokenAccount: Address,
+  mint: Address,
+  mintConfigPda: Address,
+  tokenAccountOwner: Address,
+  programAddress: Address,
+  _resolveExtra?: (addr: Address) => Promise<any>
+) {
+  return {
+    programAddress,
+    accounts: [
+      { address: (authority.address ?? authority) as string, role: 'signer' },
+      { address: tokenAccount as string },
+      { address: mint as string },
+      { address: mintConfigPda as string },
+      { address: tokenAccountOwner as string },
+    ],
+    data: new Uint8Array([1]), // dummy payload
+  };
+}
+
+export function getSetGatingProgramInstruction({
+  authority,
+  mintConfig,
+}: {
+  authority: TransactionSigner<string>;
+  mintConfig: Address;
+}): SetGatingProgramInstruction {
+  const accounts = [
+    {
+      address: authority.address as Address,
+      role: AccountRole.READONLY_SIGNER,
+      signer: authority,
+    },
+    { address: mintConfig as Address, role: AccountRole.WRITABLE },
+  ] as const;
+
+  return {
+    accounts: accounts as unknown as SetGatingProgramInstruction['accounts'],
+    programAddress:
+      'Eba1ts11111111111111111111111111111111111111' as Address<'Eba1ts11111111111111111111111111111111111111'>,
+    data: new Uint8Array([1]),
+  } as SetGatingProgramInstruction;
+}
+
+export function getTogglePermissionlessInstructionsInstruction({
+  authority,
+  mintConfig,
+}: {
+  authority: TransactionSigner<string>;
+  mintConfig: Address;
+}) {
+  return {
+    programAddress:
+      'Eba1ts11111111111111111111111111111111111111' as Address<'Eba1ts11111111111111111111111111111111111111'>,
+    accounts: [
+      {
+        address: authority.address as Address,
+        role: AccountRole.READONLY_SIGNER,
+        signer: authority,
+      },
+      { address: mintConfig as Address, role: AccountRole.WRITABLE },
+    ],
+    data: new Uint8Array([1]),
+  } as TogglePermissionlessInstructionsInstruction;
+}

--- a/packages/sdk/src/__tests__/test-utils.ts
+++ b/packages/sdk/src/__tests__/test-utils.ts
@@ -1,10 +1,21 @@
 import type { Address, Rpc, TransactionSigner } from 'gill';
+import { TOKEN_2022_PROGRAM_ADDRESS } from 'gill/programs';
 
 /**
  * Creates a mock RPC client for testing
  */
 export function createMockRpc(): Rpc<any> {
-  return {
+  const accountInfoRegistry = new Map<
+    string,
+    { owner?: Address; jsonParsed?: string; base64?: string }
+  >();
+  const programAccountsRegistry = new Map<
+    string,
+    Array<{ pubkey: Address; dataBase64: string }>
+  >();
+
+  const rpc: any = {
+    __registry: { accountInfoRegistry, programAccountsRegistry },
     getMinimumBalanceForRentExemption: (_space: bigint) => ({
       send: () => Promise.resolve(2039280n),
     }),
@@ -17,7 +28,40 @@ export function createMockRpc(): Rpc<any> {
           },
         }),
     }),
+    getAccountInfo: (
+      address: Address,
+      opts: { encoding: 'jsonParsed' | 'base64' }
+    ) => ({
+      send: async () => {
+        const entry = accountInfoRegistry.get(address as string);
+        if (!entry) return { value: null };
+        const owner = entry.owner;
+        if (opts?.encoding === 'jsonParsed') {
+          return entry.jsonParsed
+            ? { value: { data: { parsed: { info: entry.jsonParsed } }, owner } }
+            : { value: null };
+        }
+        if (opts?.encoding === 'base64') {
+          return entry.base64
+            ? { value: { data: [entry.base64, 'base64'], owner } }
+            : { value: null };
+        }
+        return { value: null };
+      },
+    }),
+    getProgramAccounts: (programAddress: Address, _opts?: any) => ({
+      send: async () => {
+        const entries =
+          programAccountsRegistry.get(programAddress as string) || [];
+        return entries.map(e => ({
+          pubkey: e.pubkey,
+          account: { data: [e.dataBase64, 'base64'] },
+        }));
+      },
+    }),
   };
+
+  return rpc as Rpc<any>;
 }
 
 /**
@@ -62,3 +106,80 @@ export const TEST_METADATA = {
  */
 export const TEST_AUTHORITY =
   'FA4EafWTpd3WEpB5hzsMjPwWnFBzjN25nKHsStgxBpiT' as Address;
+
+/**
+ * Resets all seeded data on a mock RPC created by createMockRpc.
+ */
+export function resetMockRpc(rpc: Rpc<any>): void {
+  const reg = (rpc as any).__registry;
+  if (!reg) return;
+  reg.accountInfoRegistry.clear();
+  reg.programAccountsRegistry.clear();
+}
+
+/**
+ * Seeds jsonParsed mint details at getAccountInfo for the given address.
+ */
+export function seedMintDetails(
+  rpc: Rpc<any>,
+  input: {
+    address: Address;
+    decimals: number;
+    freezeAuthority?: Address;
+    mintAuthority?: Address;
+    extensions?: any[];
+  }
+): void {
+  const reg = (rpc as any).__registry;
+  reg.accountInfoRegistry.set(input.address as string, {
+    owner: TOKEN_2022_PROGRAM_ADDRESS,
+    jsonParsed: {
+      decimals: input.decimals,
+      freezeAuthority: input.freezeAuthority,
+      mintAuthority: input.mintAuthority,
+      extensions: input.extensions ?? [],
+    },
+  });
+}
+
+/**
+ * Seeds a token account (ATA) jsonParsed info.
+ */
+export function seedTokenAccount(
+  rpc: Rpc<any>,
+  input: {
+    address: Address;
+    mint: Address;
+    owner?: Address;
+    state?: 'initialized' | 'frozen';
+    amount?: string;
+  }
+): void {
+  const reg = (rpc as any).__registry;
+  reg.accountInfoRegistry.set(input.address as string, {
+    owner: TOKEN_2022_PROGRAM_ADDRESS,
+    jsonParsed: {
+      mint: input.mint,
+      owner:
+        input.owner ?? ('OwnerMock11111111111111111111111111111111' as Address),
+      tokenAmount: { amount: input.amount ?? '0' },
+      state:
+        (input.state ?? 'initialized') === 'frozen' ? 'frozen' : 'initialized',
+    },
+  });
+}
+
+/**
+ * Seeds a base64 program account entry for getProgramAccounts.
+ * Pass already-encoded base64 data.
+ */
+export function seedProgramAccountBase64(
+  rpc: Rpc<any>,
+  programAddress: Address,
+  entry: { pubkey: Address; dataBase64: string }
+): void {
+  const reg = (rpc as any).__registry;
+  const arr = reg.programAccountsRegistry.get(programAddress as string) || [];
+  arr.push(entry);
+  reg.programAccountsRegistry.set(programAddress as string, arr);
+}

--- a/packages/sdk/src/issuance/createMint.ts
+++ b/packages/sdk/src/issuance/createMint.ts
@@ -72,9 +72,11 @@ export class Token {
     return this;
   }
 
-  withDefaultAccountState(initialState: boolean): Token {
+  withDefaultAccountState(initialStateInitialized: boolean): Token {
     const defaultAccountStateExtension = extension('DefaultAccountState', {
-      state: initialState ? AccountState.Initialized : AccountState.Frozen,
+      state: initialStateInitialized
+        ? AccountState.Initialized
+        : AccountState.Frozen,
     });
     this.extensions.push(defaultAccountStateExtension);
     return this;

--- a/packages/sdk/src/management/__tests__/lists.test.ts
+++ b/packages/sdk/src/management/__tests__/lists.test.ts
@@ -1,0 +1,151 @@
+import type { Address, Rpc, SolanaRpcApi } from 'gill';
+import { createMockSigner, createMockRpc } from '../../__tests__/test-utils';
+import { TOKEN_2022_PROGRAM_ADDRESS } from 'gill/programs';
+import { EBALTS_PROGRAM_ID } from '../../ebalts';
+import { ABL_PROGRAM_ID } from '../../abl/utils';
+import { seedTokenAccount } from '../../__tests__/test-utils';
+
+describe('non-SRFC-37 list actions produce direct freeze/thaw', () => {
+  let rpc: Rpc<SolanaRpcApi>;
+  const mint = 'Mint555555555555555555555555555555555555555' as Address;
+  const wallet = 'Wall55555555555555555555555555555555555555' as Address;
+  const authority = createMockSigner('Auth55555555555555555555555555555555555');
+
+  beforeEach(() => {
+    jest.resetModules();
+    rpc = createMockRpc();
+  });
+
+  test('blocklist add returns freeze instruction when SRFC-37 disabled', async () => {
+    jest.doMock('../../transactionUtil', () => ({
+      resolveTokenAccount: jest.fn().mockResolvedValue({
+        tokenAccount: 'Ata55555555555555555555555555555555555555',
+        isInitialized: true,
+        isFrozen: false,
+      }),
+      getMintDetails: jest.fn().mockResolvedValue({
+        decimals: 6,
+        freezeAuthority: 'NotEbalts11111111111111111111111111111111',
+        extensions: [],
+      }),
+      isDefaultAccountStateSetFrozen: jest.fn().mockReturnValue(false),
+    }));
+    const { getAddToBlocklistInstructions } = await import('../blocklist');
+    const ix = await getAddToBlocklistInstructions(
+      rpc,
+      mint,
+      wallet,
+      authority
+    );
+    expect(ix).toHaveLength(1);
+    expect(ix[0].programAddress).toBe(TOKEN_2022_PROGRAM_ADDRESS);
+  });
+
+  test('allowlist add returns thaw instruction when SRFC-37 disabled', async () => {
+    jest.doMock('../../transactionUtil', () => ({
+      resolveTokenAccount: jest.fn().mockResolvedValue({
+        tokenAccount: 'Ata66666666666666666666666666666666666666',
+        isInitialized: true,
+        isFrozen: true,
+      }),
+      getMintDetails: jest.fn().mockResolvedValue({
+        decimals: 6,
+        freezeAuthority: 'NotEbalts11111111111111111111111111111111',
+        extensions: [],
+      }),
+      isDefaultAccountStateSetFrozen: jest.fn().mockReturnValue(false),
+    }));
+    const { getAddToAllowlistInstructions } = await import('../allowlist');
+    const ix = await getAddToAllowlistInstructions(
+      rpc,
+      mint,
+      wallet,
+      authority
+    );
+    expect(ix).toHaveLength(1);
+    expect(ix[0].programAddress).toBe(TOKEN_2022_PROGRAM_ADDRESS);
+  });
+
+  test('blocklist add returns freeze instruction and add to blocklist when SRFC-37 is enabled', async () => {
+    jest.doMock('../../abl', () => ({
+      ABL_PROGRAM_ID,
+      getAddWalletInstructions: jest
+        .fn()
+        .mockResolvedValue([{ programAddress: ABL_PROGRAM_ID }]),
+      getRemoveWalletInstructions: jest
+        .fn()
+        .mockResolvedValue([{ programAddress: ABL_PROGRAM_ID }]),
+      getList: jest.fn().mockResolvedValue({ mode: 2 }),
+    }));
+    // Seed token account used by freeze path
+    seedTokenAccount(rpc, {
+      address: 'Ata55555555555555555555555555555555555555' as Address,
+      mint,
+      state: 'initialized',
+    });
+    jest.doMock('../../transactionUtil', () => ({
+      resolveTokenAccount: jest.fn().mockResolvedValue({
+        tokenAccount: 'Ata55555555555555555555555555555555555555',
+        isInitialized: true,
+        isFrozen: false,
+      }),
+      getMintDetails: jest.fn().mockResolvedValue({
+        decimals: 6,
+        freezeAuthority: EBALTS_PROGRAM_ID,
+        extensions: [{ __kind: 'DefaultAccountState', state: 'frozen' }],
+      }),
+      isDefaultAccountStateSetFrozen: jest.fn().mockReturnValue(true),
+    }));
+    const { getAddToBlocklistInstructions } = await import('../blocklist');
+    const ix = await getAddToBlocklistInstructions(
+      rpc,
+      mint,
+      wallet,
+      authority
+    );
+    // 1 for add to blocklist, 1 for freeze
+    expect(ix).toHaveLength(2);
+    expect(ix[0].programAddress).toBe(ABL_PROGRAM_ID);
+    expect(ix[1].programAddress).toBe(EBALTS_PROGRAM_ID);
+  });
+
+  test('allowlist add returns thaw instruction and add to allowlist when SRFC-37 is enabled', async () => {
+    jest.doMock('../../abl', () => ({
+      ABL_PROGRAM_ID,
+      getAddWalletInstructions: jest
+        .fn()
+        .mockResolvedValue([{ programAddress: ABL_PROGRAM_ID }]),
+      getRemoveWalletInstructions: jest
+        .fn()
+        .mockResolvedValue([{ programAddress: ABL_PROGRAM_ID }]),
+      getList: jest.fn().mockResolvedValue({ mode: 1 }),
+      getListConfigPda: jest
+        .fn()
+        .mockResolvedValue('ListCfg11111111111111111111111111111111'),
+    }));
+    jest.doMock('../../transactionUtil', () => ({
+      resolveTokenAccount: jest.fn().mockResolvedValue({
+        tokenAccount: 'Ata66666666666666666666666666666666666666',
+        isInitialized: true,
+        isFrozen: true,
+      }),
+      getMintDetails: jest.fn().mockResolvedValue({
+        decimals: 6,
+        freezeAuthority: EBALTS_PROGRAM_ID,
+        extensions: [{ __kind: 'DefaultAccountState', state: 'frozen' }],
+      }),
+      isDefaultAccountStateSetFrozen: jest.fn().mockReturnValue(true),
+    }));
+    const { getAddToAllowlistInstructions } = await import('../allowlist');
+    const ix = await getAddToAllowlistInstructions(
+      rpc,
+      mint,
+      wallet,
+      authority
+    );
+    // 1 for add to allowlist, 1 for thaw permissionless
+    expect(ix).toHaveLength(2);
+    expect(ix[0].programAddress).toBe(ABL_PROGRAM_ID);
+    expect(ix[1].programAddress).toBe(EBALTS_PROGRAM_ID);
+  });
+});

--- a/packages/sdk/src/management/__tests__/mint-force.test.ts
+++ b/packages/sdk/src/management/__tests__/mint-force.test.ts
@@ -1,0 +1,153 @@
+import type { Address, Rpc, SolanaRpcApi } from 'gill';
+import { createMockSigner, createMockRpc } from '../../__tests__/test-utils';
+import { EBALTS_PROGRAM_ID } from '../../ebalts';
+
+describe('non-SRFC-37: mint/force-transfer should not include permissionless thaw', () => {
+  let rpc: Rpc<SolanaRpcApi>;
+  const mint = 'Mint777777777777777777777777777777777777777' as Address;
+  const wallet = 'Wall77777777777777777777777777777777777777' as Address;
+  const feePayer = createMockSigner('Fee777777777777777777777777777777777777');
+  const mintAuthority = createMockSigner(
+    'MintAuth77777777777777777777777777777777777'
+  );
+  const permDel = createMockSigner('PermDel777777777777777777777777777777777');
+
+  beforeEach(() => {
+    jest.resetModules();
+    rpc = createMockRpc();
+  });
+
+  test('createMintToTransaction: no thaw permissionless when SRFC-37 disabled', async () => {
+    jest.doMock('../../transactionUtil', () => ({
+      resolveTokenAccount: jest.fn().mockResolvedValue({
+        tokenAccount: 'Ata77777777777777777777777777777777777777',
+        isInitialized: true,
+        isFrozen: true,
+      }),
+      decimalAmountToRaw: jest.fn().mockReturnValue(1n),
+      getMintDetails: jest.fn().mockResolvedValue({
+        decimals: 6,
+        freezeAuthority: 'NotEbalts11111111111111111111111111111111',
+        extensions: [],
+      }),
+      isDefaultAccountStateSetFrozen: jest.fn().mockReturnValue(false),
+    }));
+    const { createMintToTransaction } = await import('../mint');
+    const tx = await createMintToTransaction(
+      rpc,
+      mint,
+      wallet,
+      1,
+      mintAuthority,
+      feePayer
+    );
+    expect(tx.instructions.some(i => i.programAddress !== undefined)).toBe(
+      true
+    );
+    expect(tx.instructions.length).toBe(2);
+  });
+
+  test('createForceTransferTransaction: no thaw permissionless when SRFC-37 disabled', async () => {
+    jest.doMock('../../transactionUtil', () => ({
+      resolveTokenAccount: jest
+        .fn()
+        .mockResolvedValueOnce({
+          tokenAccount: 'FromATA',
+          isInitialized: true,
+          isFrozen: false,
+        })
+        .mockResolvedValueOnce({
+          tokenAccount: 'ToATA',
+          isInitialized: false,
+          isFrozen: false,
+        }),
+      decimalAmountToRaw: jest.fn().mockReturnValue(1n),
+      getMintDetails: jest.fn().mockResolvedValue({
+        decimals: 6,
+        freezeAuthority: 'NotEbalts11111111111111111111111111111111',
+        extensions: [],
+      }),
+      isDefaultAccountStateSetFrozen: jest.fn().mockReturnValue(false),
+    }));
+    const { createForceTransferTransaction } = await import(
+      '../force-transfer'
+    );
+    const tx = await createForceTransferTransaction(
+      rpc,
+      mint,
+      wallet,
+      wallet,
+      1,
+      permDel,
+      feePayer
+    );
+    // Should only include transfer (and create ATA) but not thaw-permissionless
+    expect(tx.instructions.length).toBe(2);
+  });
+
+  test('createMintToTransaction: thaw permissionless when SRFC-37 is enabled', async () => {
+    jest.doMock('../../transactionUtil', () => ({
+      resolveTokenAccount: jest.fn().mockResolvedValue({
+        tokenAccount: 'Ata77777777777777777777777777777777777777',
+        isInitialized: false,
+        isFrozen: true,
+      }),
+      decimalAmountToRaw: jest.fn().mockReturnValue(1n),
+      getMintDetails: jest.fn().mockResolvedValue({
+        decimals: 6,
+        freezeAuthority: EBALTS_PROGRAM_ID,
+        extensions: [{ __kind: 'DefaultAccountState', state: 'frozen' }],
+      }),
+      isDefaultAccountStateSetFrozen: jest.fn().mockReturnValue(true),
+    }));
+    const { createMintToTransaction } = await import('../mint');
+    const tx = await createMintToTransaction(
+      rpc,
+      mint,
+      wallet,
+      1,
+      mintAuthority,
+      feePayer
+    );
+    // Should include mint, create ATA, and thaw-permissionless
+    expect(tx.instructions.length).toBe(3);
+  });
+
+  test('createForceTransferTransaction: thaw permissionless when SRFC-37 is enabled', async () => {
+    jest.doMock('../../transactionUtil', () => ({
+      resolveTokenAccount: jest
+        .fn()
+        .mockResolvedValueOnce({
+          tokenAccount: 'FromATA',
+          isInitialized: true,
+          isFrozen: false,
+        })
+        .mockResolvedValueOnce({
+          tokenAccount: 'ToATA',
+          isInitialized: false,
+          isFrozen: true,
+        }),
+      decimalAmountToRaw: jest.fn().mockReturnValue(1n),
+      getMintDetails: jest.fn().mockResolvedValue({
+        decimals: 6,
+        freezeAuthority: EBALTS_PROGRAM_ID,
+        extensions: [{ __kind: 'DefaultAccountState', state: 'frozen' }],
+      }),
+      isDefaultAccountStateSetFrozen: jest.fn().mockReturnValue(true),
+    }));
+    const { createForceTransferTransaction } = await import(
+      '../force-transfer'
+    );
+    const tx = await createForceTransferTransaction(
+      rpc,
+      mint,
+      wallet,
+      wallet,
+      1,
+      permDel,
+      feePayer
+    );
+    // Should include transfer, create ATA, and thaw-permissionless
+    expect(tx.instructions.length).toBe(3);
+  });
+});

--- a/packages/sdk/src/management/allowlist.ts
+++ b/packages/sdk/src/management/allowlist.ts
@@ -74,7 +74,6 @@ export const getAddToAllowlistInstructions = async (
     authority: accountSigner.address,
     mint,
   });
-  console.log('listConfigPda', listConfigPda);
   if (!(await isAblAllowlist(rpc, listConfigPda))) {
     throw new Error('This is not an ABL allowlist');
   }

--- a/packages/sdk/src/management/allowlist.ts
+++ b/packages/sdk/src/management/allowlist.ts
@@ -7,7 +7,11 @@ import {
   type SolanaRpcApi,
   type TransactionSigner,
 } from 'gill';
-import { resolveTokenAccount } from '../transactionUtil';
+import {
+  getMintDetails,
+  isDefaultAccountStateSetFrozen,
+  resolveTokenAccount,
+} from '../transactionUtil';
 import {
   ABL_PROGRAM_ID,
   getAddWalletInstructions,
@@ -18,6 +22,12 @@ import {
 import { findListConfigPda, Mode } from '@mosaic/abl';
 import { getFreezeInstructions } from '../ebalts/freeze';
 import { getThawPermissionlessInstructions } from '../ebalts/thawPermissionless';
+import { EBALTS_PROGRAM_ID } from '../ebalts';
+import {
+  getFreezeAccountInstruction,
+  getThawAccountInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS,
+} from 'gill/programs';
 
 export const isAblAllowlist = async (
   rpc: Rpc<SolanaRpcApi>,
@@ -40,6 +50,26 @@ export const getAddToAllowlistInstructions = async (
   );
   const accountSigner =
     typeof authority === 'string' ? createNoopSigner(authority) : authority;
+  const { freezeAuthority, extensions } = await getMintDetails(rpc, mint);
+  const enableSrfc37 =
+    freezeAuthority === EBALTS_PROGRAM_ID &&
+    isDefaultAccountStateSetFrozen(extensions);
+
+  if (!enableSrfc37) {
+    return [
+      getThawAccountInstruction(
+        {
+          account: tokenAccount,
+          mint,
+          owner: accountSigner,
+        },
+        {
+          programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+        }
+      ),
+    ];
+  }
+
   const listConfigPda = await getListConfigPda({
     authority: accountSigner.address,
     mint,
@@ -103,6 +133,26 @@ export const getRemoveFromAllowlistInstructions = async (
   const accountSigner =
     typeof authority === 'string' ? createNoopSigner(authority) : authority;
 
+  const { freezeAuthority, extensions } = await getMintDetails(rpc, mint);
+  const enableSrfc37 =
+    freezeAuthority === EBALTS_PROGRAM_ID &&
+    isDefaultAccountStateSetFrozen(extensions);
+
+  if (!enableSrfc37) {
+    return [
+      getFreezeAccountInstruction(
+        {
+          account: destinationAta,
+          mint,
+          owner: accountSigner,
+        },
+        {
+          programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+        }
+      ),
+    ];
+  }
+
   const listConfigPda = await findListConfigPda(
     {
       authority: accountSigner.address,
@@ -121,7 +171,8 @@ export const getRemoveFromAllowlistInstructions = async (
   });
   instructions.push(...removeFromAllowlistInstructions);
 
-  if (isInitialized && isFrozen) {
+  const useSrfc37 = enableSrfc37 ?? false;
+  if (isInitialized && isFrozen && useSrfc37) {
     // TODO: this should freeze all accounts owned by the wallet
     const freezeInstructions = await getFreezeInstructions({
       rpc,

--- a/packages/sdk/src/templates/__tests__/templates-srfc37.test.ts
+++ b/packages/sdk/src/templates/__tests__/templates-srfc37.test.ts
@@ -1,0 +1,139 @@
+import type { Address, Rpc, SolanaRpcApi } from 'gill';
+import { createMockSigner, createMockRpc } from '../../__tests__/test-utils';
+import {
+  TOKEN_2022_PROGRAM_ADDRESS,
+  getInitializeMintInstruction,
+  extension,
+  AccountState,
+  getPreInitializeInstructionsForMintExtensions,
+} from 'gill/programs/token';
+
+describe('templates enableSrfc37 option', () => {
+  let rpc: Rpc<SolanaRpcApi>;
+  const feePayer = createMockSigner();
+  const mintAuthority = feePayer.address as Address;
+  const mint = createMockSigner();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    rpc = createMockRpc();
+  });
+
+  test('arcade token: enableSrfc37 false uses default account state initialized', async () => {
+    const decimals = 6;
+    const { createArcadeTokenInitTransaction } = await import('../arcadeToken');
+    const tx = await createArcadeTokenInitTransaction(
+      rpc,
+      'Name',
+      'SYM',
+      decimals,
+      'uri',
+      mintAuthority,
+      mint,
+      feePayer,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false
+    );
+
+    const instructions = tx.instructions;
+    expect(instructions.length).toBeGreaterThan(0);
+
+    const expectedInit = getInitializeMintInstruction(
+      {
+        mint: mint.address,
+        decimals,
+        freezeAuthority: mintAuthority,
+        mintAuthority: feePayer.address,
+      },
+      { programAddress: TOKEN_2022_PROGRAM_ADDRESS }
+    );
+    const hasInit = instructions.some(
+      i =>
+        i.programAddress === expectedInit.programAddress &&
+        Buffer.compare(
+          Buffer.from(i.data ?? []),
+          Buffer.from(expectedInit.data)
+        ) === 0
+    );
+    expect(hasInit).toBe(true);
+
+    const defaultStateExt = extension('DefaultAccountState', {
+      state: AccountState.Initialized,
+    });
+    const [expectedDefaultStateInit] =
+      getPreInitializeInstructionsForMintExtensions(mint.address, [
+        defaultStateExt,
+      ]);
+    const hasDefaultInitialized = instructions.some(
+      i =>
+        i.programAddress === expectedDefaultStateInit.programAddress &&
+        Buffer.compare(
+          Buffer.from(i.data ?? []),
+          Buffer.from(expectedDefaultStateInit.data ?? [])
+        ) === 0
+    );
+    expect(hasDefaultInitialized).toBe(true);
+  });
+
+  test('arcade token: enableSrfc37 true uses default account state frozen', async () => {
+    const decimals = 6;
+    const { createArcadeTokenInitTransaction } = await import('../arcadeToken');
+    const tx = await createArcadeTokenInitTransaction(
+      rpc,
+      'Name',
+      'SYM',
+      decimals,
+      'uri',
+      mintAuthority,
+      mint,
+      feePayer,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true
+    );
+
+    const instructions = tx.instructions;
+    expect(instructions.length).toBeGreaterThan(0);
+
+    const expectedInit = getInitializeMintInstruction(
+      {
+        mint: mint.address,
+        decimals,
+        freezeAuthority: mintAuthority,
+        mintAuthority: feePayer.address,
+      },
+      { programAddress: TOKEN_2022_PROGRAM_ADDRESS }
+    );
+    const hasInit = instructions.some(
+      i =>
+        i.programAddress === expectedInit.programAddress &&
+        Buffer.compare(
+          Buffer.from(i.data ?? []),
+          Buffer.from(expectedInit.data)
+        ) === 0
+    );
+    expect(hasInit).toBe(true);
+
+    const defaultStateExt = extension('DefaultAccountState', {
+      state: AccountState.Frozen,
+    });
+    const [expectedDefaultStateInit] =
+      getPreInitializeInstructionsForMintExtensions(mint.address, [
+        defaultStateExt,
+      ]);
+    const hasDefaultInitialized = instructions.some(
+      i =>
+        i.programAddress === expectedDefaultStateInit.programAddress &&
+        Buffer.compare(
+          Buffer.from(i.data ?? []),
+          Buffer.from(expectedDefaultStateInit.data ?? [])
+        ) === 0
+    );
+    expect(hasDefaultInitialized).toBe(true);
+  });
+});

--- a/packages/sdk/src/templates/arcadeToken.ts
+++ b/packages/sdk/src/templates/arcadeToken.ts
@@ -51,7 +51,8 @@ export const createArcadeTokenInitTransaction = async (
   metadataAuthority?: Address,
   pausableAuthority?: Address,
   confidentialBalancesAuthority?: Address,
-  permanentDelegateAuthority?: Address
+  permanentDelegateAuthority?: Address,
+  enableSrfc37?: boolean
 ): Promise<
   FullTransaction<
     TransactionVersion,
@@ -62,6 +63,7 @@ export const createArcadeTokenInitTransaction = async (
   const mintSigner = typeof mint === 'string' ? createNoopSigner(mint) : mint;
   const feePayerSigner =
     typeof feePayer === 'string' ? createNoopSigner(feePayer) : feePayer;
+  const useSrfc37 = enableSrfc37 ?? false;
   const instructions = await new Token()
     .withMetadata({
       mintAddress: mintSigner.address,
@@ -85,8 +87,8 @@ export const createArcadeTokenInitTransaction = async (
       feePayer: feePayerSigner,
     });
 
-  // 2. create mintConfig (ebalts)
-  if (mintAuthority !== feePayerSigner.address) {
+  // 2. create mintConfig (ebalts) - only if SRFC-37 is enabled
+  if (mintAuthority !== feePayerSigner.address || !useSrfc37) {
     // Get latest blockhash for transaction
     const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 

--- a/packages/sdk/src/templates/arcadeToken.ts
+++ b/packages/sdk/src/templates/arcadeToken.ts
@@ -77,7 +77,7 @@ export const createArcadeTokenInitTransaction = async (
       additionalMetadata: new Map(),
     })
     .withPausable(pausableAuthority || mintAuthority)
-    .withDefaultAccountState(false)
+    .withDefaultAccountState(!useSrfc37)
     .withPermanentDelegate(permanentDelegateAuthority || mintAuthority)
     .buildInstructions({
       rpc,

--- a/packages/sdk/src/templates/stablecoin.ts
+++ b/packages/sdk/src/templates/stablecoin.ts
@@ -51,7 +51,8 @@ export const createStablecoinInitTransaction = async (
   metadataAuthority?: Address,
   pausableAuthority?: Address,
   confidentialBalancesAuthority?: Address,
-  permanentDelegateAuthority?: Address
+  permanentDelegateAuthority?: Address,
+  enableSrfc37?: boolean
 ): Promise<
   FullTransaction<
     TransactionVersion,
@@ -64,6 +65,7 @@ export const createStablecoinInitTransaction = async (
     typeof feePayer === 'string' ? createNoopSigner(feePayer) : feePayer;
 
   aclMode = aclMode || 'blocklist';
+  const useSrfc37 = enableSrfc37 ?? false;
 
   // 1. create token
   const instructions = await new Token()
@@ -90,8 +92,8 @@ export const createStablecoinInitTransaction = async (
       feePayer: feePayerSigner,
     });
 
-  // 2. create mintConfig (ebalts)
-  if (mintAuthority !== feePayerSigner.address) {
+  // 2. create mintConfig (ebalts) - only if SRFC-37 is enabled
+  if (mintAuthority !== feePayerSigner.address || !useSrfc37) {
     // Get latest blockhash for transaction
     const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 

--- a/packages/sdk/src/templates/stablecoin.ts
+++ b/packages/sdk/src/templates/stablecoin.ts
@@ -81,7 +81,7 @@ export const createStablecoinInitTransaction = async (
       additionalMetadata: new Map(),
     })
     .withPausable(pausableAuthority || mintAuthority)
-    .withDefaultAccountState(false)
+    .withDefaultAccountState(!useSrfc37)
     .withConfidentialBalances(confidentialBalancesAuthority || mintAuthority)
     .withPermanentDelegate(permanentDelegateAuthority || mintAuthority)
     .buildInstructions({

--- a/packages/sdk/src/templates/tokenizedSecurity.ts
+++ b/packages/sdk/src/templates/tokenizedSecurity.ts
@@ -77,7 +77,7 @@ export const createTokenizedSecurityInitTransaction = async (
       additionalMetadata: new Map(),
     })
     .withPausable(pausableAuthority)
-    .withDefaultAccountState(false)
+    .withDefaultAccountState(!useSrfc37)
     .withConfidentialBalances(confidentialBalancesAuthority)
     .withPermanentDelegate(permanentDelegateAuthority);
 

--- a/packages/sdk/src/templates/tokenizedSecurity.ts
+++ b/packages/sdk/src/templates/tokenizedSecurity.ts
@@ -37,6 +37,7 @@ export const createTokenizedSecurityInitTransaction = async (
     pausableAuthority?: Address;
     confidentialBalancesAuthority?: Address;
     permanentDelegateAuthority?: Address;
+    enableSrfc37?: boolean;
     scaledUiAmount?: {
       authority?: Address;
       multiplier?: number;
@@ -56,6 +57,7 @@ export const createTokenizedSecurityInitTransaction = async (
     typeof feePayer === 'string' ? createNoopSigner(feePayer) : feePayer;
 
   const aclMode = options?.aclMode ?? 'blocklist';
+  const useSrfc37 = options?.enableSrfc37 ?? false;
   const metadataAuthority = options?.metadataAuthority || mintAuthority;
   const pausableAuthority = options?.pausableAuthority || mintAuthority;
   const confidentialBalancesAuthority =
@@ -95,7 +97,7 @@ export const createTokenizedSecurityInitTransaction = async (
     feePayer: feePayerSigner,
   });
 
-  if (mintAuthority !== feePayerSigner.address) {
+  if (mintAuthority !== feePayerSigner.address || !useSrfc37) {
     const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
     return createTransaction({
       feePayer,


### PR DESCRIPTION
### Make SRFC‑37 optional across SDK flows

#### Why
sRFC-37 is not ready for production yet. This change lets all management and template flows work whether SRFC‑37 is present or not, auto‑detecting it at runtime and falling back to Token‑2022 primitives when absent.

### What’s changed
- **Runtime detection of SRFC‑37**
  - We consider SRFC‑37 “enabled” when:
    - **freezeAuthority** is `EBALTS_PROGRAM_ID`, and
    - **DefaultAccountState** extension is set to `frozen`.
  - New util: `isDefaultAccountStateSetFrozen(extensions: any[]): boolean`.
- **Allowlist/Blocklist flows**
  - If SRFC‑37 is enabled: use ABL lists + EBALTS instructions.
  - If not: fall back to Token‑2022 `freeze/thaw` on the destination ATA only.
- **Mint and force‑transfer**
  - If the target account is frozen:
    - With SRFC‑37: use permissionless thaw via EBALTS.
    - Without SRFC‑37: use Token‑2022 thaw.
- **Templates (`arcadeToken`, `stablecoin`, `tokenizedSecurity`)**
  - New option: `enableSrfc37?: boolean` (default `false`).
  - When enabled, include EBALTS config + set ABL as gating program.
  - When disabled, skip EBALTS/ABL setup; mint works without SRFC‑37.

### API changes
- Templates accept `enableSrfc37?: boolean`.
- No breaking changes to existing management APIs; SRFC‑37 usage is auto‑detected.

### Behavior details
- **When SRFC‑37 is enabled**
  - Allowlist remove: unfreeze via EBALTS permissionless thaw after removal.
  - Blocklist remove: unfreeze via EBALTS permissionless thaw after removal.
  - Mint/force‑transfer: thaw frozen accounts permissionlessly as needed.
- **When SRFC‑37 is disabled**
  - Allowlist remove: direct Token‑2022 `freeze`/`thaw` as appropriate.
  - Blocklist remove: direct Token‑2022 `freeze`/`thaw`.

### Migration
- None required. Existing consumers continue to work.
- To opt into SRFC‑37 during token creation, pass `enableSrfc37: true` to templates.

### How to test
- Create tokens with `enableSrfc37: true` and `false`; verify:
  - When true, EBALTS config is created and ABL set as gating program.
  - When false, no EBALTS/ABL PDAs are created; flows still function using Token‑2022.
- Exercise allowlist/blocklist add/remove, `mint`, and `force-transfer` against both kinds of mints and confirm correct freeze/thaw behavior.

### Checklist
- [ ] Add docs for `enableSrfc37` in template README(s)
- [ ] Add example snippets for both SRFC‑37 and non‑SRFC‑37 tokens
- [ ] Confirm CI/tests pass for both configurations