### PR TITLE
Fix TypeScript build isolation in monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "pnpm --recursive run build",
+    "build": "pnpm --recursive --stream run build",
     "dev": "pnpm --recursive run dev",
     "ui": "pnpm --filter @mosaic/ui run dev",
     "test": "pnpm --recursive run test --passWithNoTests",

--- a/packages/abl/package.json
+++ b/packages/abl/package.json
@@ -15,7 +15,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "dev": "echo 'Dev will be implemented'",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/packages/abl/tsconfig.json
+++ b/packages/abl/tsconfig.json
@@ -1,10 +1,12 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "verbatimModuleSyntax": false
+    "rootDir": "./src",
+    "noEmit": false,
+    "verbatimModuleSyntax": false,
+    "composite": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"],
-  "types": ["jest", "node"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
     "test": "echo 'Tests will be implemented'",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,9 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "noEmit": false,
     "outDir": "./dist",
+    "rootDir": "./src",
     "module": "ES2022",
     "target": "ES2022",
     "moduleResolution": "bundler",
@@ -11,8 +13,15 @@
     "declarationMap": true,
     "sourceMap": true,
     "skipLibCheck": true,
-    "allowImportingTsExtensions": false
+    "allowImportingTsExtensions": false,
+    "composite": true
   },
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"]
+  "exclude": ["dist", "node_modules"],
+  "references": [
+    { "path": "../sdk" },
+    { "path": "../tlv-account-resolution" },
+    { "path": "../token-acl" },
+    { "path": "../abl" }
+  ]
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -15,7 +15,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "dev": "tsc --watch",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,11 +1,17 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
+    "rootDir": "./src",
     "noEmit": false,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "composite": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"],
-  "types": ["jest", "node"]
+  "references": [
+    { "path": "../tlv-account-resolution" },
+    { "path": "../token-acl" },
+    { "path": "../abl" }
+  ]
 }

--- a/packages/tlv-account-resolution/package.json
+++ b/packages/tlv-account-resolution/package.json
@@ -15,7 +15,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "dev": "echo 'Dev will be implemented'",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/packages/tlv-account-resolution/tsconfig.json
+++ b/packages/tlv-account-resolution/tsconfig.json
@@ -1,10 +1,11 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "noEmit": false,
+    "composite": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"],
-  "types": ["jest", "node"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/token-acl/package.json
+++ b/packages/token-acl/package.json
@@ -15,7 +15,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -b",
     "dev": "echo 'Dev will be implemented'",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/packages/token-acl/tsconfig.json
+++ b/packages/token-acl/tsconfig.json
@@ -1,10 +1,13 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "verbatimModuleSyntax": false
+    "rootDir": "./src",
+    "noEmit": false,
+    "verbatimModuleSyntax": false,
+    "composite": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"],
-  "types": ["jest", "node"]
+  "references": [{ "path": "../tlv-account-resolution" }]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "verbatimModuleSyntax": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "removeComments": false,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "exclude": [
+    "node_modules",
+    "**/dist",
+    "**/build",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,6 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "verbatimModuleSyntax": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "removeComments": false,
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
     "baseUrl": ".",
     "paths": {
       "@mosaic/core": ["./packages/core/src"],
@@ -33,12 +14,11 @@
       "@mosaic/abl": ["./packages/abl/src"]
     }
   },
-  "include": ["packages/*/src/**/*", "*.ts", "*.tsx"],
-  "exclude": [
-    "node_modules",
-    "**/dist",
-    "**/build",
-    "**/*.test.ts",
-    "**/*.test.tsx"
+  "references": [
+    { "path": "./packages/tlv-account-resolution" },
+    { "path": "./packages/abl" },
+    { "path": "./packages/token-acl" },
+    { "path": "./packages/sdk" },
+    { "path": "./packages/cli" }
   ]
 }


### PR DESCRIPTION
## Fix TypeScript build isolation in monorepo

### Summary

• Fixed monorepo build process so each package builds only its own source files to its respective dist folder
• Implemented TypeScript project references for proper dependency management

### Problem

When running pnpm build from the root, each package was incorrectly compiling ALL packages' source files into its own dist folder. For example,
the CLI package's dist folder contained compiled code from abl, sdk, tlv-account-resolution, and token-acl packages, leading to:

• Bloated dist folders with unnecessary files
• Potential version conflicts and runtime issues
• Longer build times
• Confusing build outputs

### Solution

Implemented TypeScript project references and proper build isolation:

1. Created tsconfig.base.json - Extracted shared TypeScript configuration without problematic include patterns
2. Updated package configurations - Each package now:
 • Extends from tsconfig.base.json instead of root config
 • Uses composite: true for project references
 • Specifies rootDir: "./src" to constrain compilation scope
 • Declares explicit references to dependencies
3. Improved build scripts - Changed from tsc to tsc -b for project reference support
4. Enhanced build output - Added --stream flag for better visibility during builds

### Changes by package

• All packages: Updated tsconfig.json to use project references and tsc -b
• Root: Split TypeScript config into base and root, maintaining path mappings for development

### Testing

• ✅ Each package now builds only its own source files
• ✅ Dependency resolution works correctly through project references
• ✅ Development imports using @mosaic/* syntax still function
• ✅ Build respects dependency order automatically