### PR TITLE
Add the ability to import your own token

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,3 +7,4 @@ export * from './abl';
 export * from './token-acl';
 export * from './token';
 export * from './transfer';
+export * from './inspection';

--- a/packages/sdk/src/inspection/index.ts
+++ b/packages/sdk/src/inspection/index.ts
@@ -1,0 +1,19 @@
+export {
+  inspectToken,
+  getTokenMetadata,
+  getTokenExtensionsDetailed,
+  detectTokenTypeFromMint,
+  inspectionResultToDashboardData,
+  getTokenDashboardData,
+} from './inspectToken';
+export type {
+  TokenMetadata,
+  TokenAuthorities,
+  TokenSupplyInfo,
+  TokenExtension,
+  TokenType,
+  TokenInspectionResult,
+  TokenDashboardData,
+  AclMode,
+  ScaledUiAmountInfo,
+} from './types';

--- a/packages/sdk/src/inspection/inspectToken.ts
+++ b/packages/sdk/src/inspection/inspectToken.ts
@@ -1,0 +1,504 @@
+import {
+  type Address,
+  fetchEncodedAccount,
+  type Rpc,
+  type SolanaRpcApi,
+  address,
+  getAddressEncoder,
+  getProgramDerivedAddress,
+} from 'gill';
+import {
+  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
+  decodeMint,
+} from 'gill/programs/token';
+import type {
+  AclMode,
+  ScaledUiAmountInfo,
+  TokenAuthorities,
+  TokenDashboardData,
+  TokenExtension,
+  TokenInspectionResult,
+  TokenMetadata,
+  TokenSupplyInfo,
+  TokenType,
+} from './types';
+import { TOKEN_ACL_PROGRAM_ID } from '../token-acl';
+
+// Metaplex Token Metadata Program ID
+const METADATA_PROGRAM_ID = address(
+  'metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s'
+);
+
+const STABLECOIN_EXTENSIONS = [
+  'TokenMetadata',
+  'PermanentDelegate',
+  'DefaultAccountState',
+  'ConfidentialTransferMint',
+];
+
+const ARCADE_TOKEN_EXTENSIONS = [
+  'TokenMetadata',
+  'PermanentDelegate',
+  'DefaultAccountState',
+];
+
+const TOKENIZED_SECURITY_EXTENSIONS = [
+  'TokenMetadata',
+  'PermanentDelegate',
+  'DefaultAccountState',
+];
+
+// Helper function to derive Metaplex metadata account address
+async function deriveMetadataAccount(mintAddress: Address): Promise<Address> {
+  const seeds = [
+    Buffer.from('metadata'),
+    getAddressEncoder().encode(METADATA_PROGRAM_ID),
+    getAddressEncoder().encode(mintAddress),
+  ];
+
+  const [metadataAccount] = await getProgramDerivedAddress({
+    programAddress: METADATA_PROGRAM_ID,
+    seeds,
+  });
+
+  return metadataAccount;
+}
+
+// Helper function to fetch and parse Metaplex metadata
+async function fetchMetaplexMetadata(
+  rpc: Rpc<SolanaRpcApi>,
+  mintAddress: Address
+): Promise<TokenMetadata | null> {
+  try {
+    const metadataAccount = await deriveMetadataAccount(mintAddress);
+    const accountInfo = await fetchEncodedAccount(rpc, metadataAccount);
+
+    if (!accountInfo.exists) {
+      return null;
+    }
+
+    // Parse the metadata account data
+    // Metaplex metadata has a specific structure
+    const data = accountInfo.data;
+
+    if (!data || data.length < 100) {
+      return null;
+    }
+
+    // Skip the discriminator and key (first 1 byte)
+    let offset = 1;
+
+    // Skip update authority (32 bytes)
+    offset += 32;
+
+    // Skip mint (32 bytes)
+    offset += 32;
+
+    // Read name (32 bytes for length + string)
+    const nameLength =
+      data[offset] |
+      (data[offset + 1] << 8) |
+      (data[offset + 2] << 16) |
+      (data[offset + 3] << 24);
+    offset += 4;
+    const nameBytes = data.slice(offset, offset + nameLength);
+    const name = new TextDecoder().decode(nameBytes).replace(/\0/g, '').trim();
+    offset += 32; // Name is always padded to 32 bytes in the account
+
+    // Read symbol (10 bytes for length + string)
+    const symbolLength =
+      data[offset] |
+      (data[offset + 1] << 8) |
+      (data[offset + 2] << 16) |
+      (data[offset + 3] << 24);
+    offset += 4;
+    const symbolBytes = data.slice(offset, offset + symbolLength);
+    const symbol = new TextDecoder()
+      .decode(symbolBytes)
+      .replace(/\0/g, '')
+      .trim();
+    offset += 10; // Symbol is always padded to 10 bytes
+
+    // Read URI (200 bytes for length + string)
+    const uriLength =
+      data[offset] |
+      (data[offset + 1] << 8) |
+      (data[offset + 2] << 16) |
+      (data[offset + 3] << 24);
+    offset += 4;
+    const uriBytes = data.slice(offset, offset + uriLength);
+    const uri = new TextDecoder().decode(uriBytes).replace(/\0/g, '').trim();
+
+    return {
+      name: name || undefined,
+      symbol: symbol || undefined,
+      uri: uri || undefined,
+    };
+  } catch (error) {
+    console.error('Error fetching Metaplex metadata:', error);
+    return null;
+  }
+}
+
+export async function inspectToken(
+  rpc: Rpc<SolanaRpcApi>,
+  mintAddress: Address
+): Promise<TokenInspectionResult> {
+  // Fetch the mint account
+  const encodedAccount = await fetchEncodedAccount(rpc, mintAddress);
+
+  if (!encodedAccount.exists) {
+    throw new Error(`Mint account not found at address: ${mintAddress}`);
+  }
+
+  // Check if this is a Token or Token-2022 mint
+  const isToken2022 =
+    encodedAccount.programAddress === TOKEN_2022_PROGRAM_ADDRESS;
+  const isToken = encodedAccount.programAddress === TOKEN_PROGRAM_ADDRESS;
+
+  if (!isToken2022 && !isToken) {
+    throw new Error(
+      `Invalid mint account. Program owner: ${encodedAccount.programAddress}`
+    );
+  }
+
+  // Decode mint data
+  const decodedMint = decodeMint(encodedAccount);
+
+  // Extract basic supply information
+  const supplyInfo: TokenSupplyInfo = {
+    supply: decodedMint.data.supply,
+    decimals: decodedMint.data.decimals,
+    isInitialized: decodedMint.data.isInitialized,
+  };
+
+  // Initialize authorities with basic ones from mint
+  const authorities: TokenAuthorities = {
+    mintAuthority:
+      decodedMint.data.mintAuthority?.__option === 'Some'
+        ? decodedMint.data.mintAuthority.value
+        : null,
+    freezeAuthority:
+      decodedMint.data.freezeAuthority?.__option === 'Some'
+        ? decodedMint.data.freezeAuthority.value
+        : null,
+  };
+
+  // Process extensions (only for Token-2022)
+  const extensions: TokenExtension[] = [];
+  let metadata: TokenMetadata | undefined;
+  let isPausable = false;
+  let aclMode: AclMode = 'none';
+  let enableSrfc37 = false;
+  let scaledUiAmount: ScaledUiAmountInfo | undefined;
+
+  if (isToken2022 && decodedMint.data.extensions?.__option === 'Some') {
+    for (const ext of decodedMint.data.extensions.value) {
+      if (!ext.__kind) continue;
+
+      const extensionDetails: Record<string, any> = {};
+
+      switch (ext.__kind) {
+        case 'TokenMetadata':
+          // Extract metadata and metadata authority
+          metadata = {
+            name: ext.name,
+            symbol: ext.symbol,
+            uri: ext.uri,
+            updateAuthority:
+              ext.updateAuthority?.__option === 'Some'
+                ? ext.updateAuthority.value
+                : null,
+          };
+
+          // Set metadata authority
+          authorities.metadataAuthority = metadata.updateAuthority;
+          authorities.updateAuthority = metadata.updateAuthority;
+
+          // Add additional metadata if present
+          if (ext.additionalMetadata && ext.additionalMetadata.size > 0) {
+            metadata.additionalMetadata = new Map();
+            for (const [key, value] of ext.additionalMetadata.entries()) {
+              metadata.additionalMetadata.set(key, value);
+            }
+          }
+
+          extensions.push({
+            name: 'TokenMetadata',
+            details: { ...metadata },
+          });
+          break;
+
+        case 'DefaultAccountState':
+          extensionDetails.state = ext.state;
+
+          // Determine ACL mode based on state
+          // AccountState is likely an enum, so we need to check its string representation
+          const stateStr = String(ext.state);
+          if (stateStr === 'Frozen' || stateStr === '2') {
+            aclMode = 'allowlist'; // Frozen by default = allowlist
+          } else if (stateStr === 'Initialized' || stateStr === '1') {
+            aclMode = 'blocklist'; // Initialized by default = blocklist
+          }
+
+          extensions.push({
+            name: 'DefaultAccountState',
+            details: extensionDetails,
+          });
+          break;
+
+        case 'PermanentDelegate':
+          if (ext.delegate) {
+            authorities.permanentDelegate = ext.delegate;
+            authorities.permanentDelegateAuthority = ext.delegate;
+            extensionDetails.delegate = ext.delegate;
+          }
+          extensions.push({
+            name: 'PermanentDelegate',
+            details: extensionDetails,
+          });
+          break;
+
+        case 'ConfidentialTransferMint':
+          const confidentialAuthority =
+            ext.authority?.__option === 'Some' ? ext.authority.value : null;
+
+          authorities.confidentialBalancesAuthority = confidentialAuthority;
+          extensionDetails.authority = confidentialAuthority;
+          extensionDetails.autoApproveNewAccounts = ext.autoApproveNewAccounts;
+
+          extensions.push({
+            name: 'ConfidentialTransferMint',
+            details: extensionDetails,
+          });
+          break;
+
+        case 'PausableConfig':
+          const pausableAuthority =
+            ext.authority?.__option === 'Some' ? ext.authority.value : null;
+
+          authorities.pausableAuthority = pausableAuthority;
+          extensionDetails.authority = pausableAuthority;
+          extensionDetails.paused = ext.paused;
+          isPausable = true;
+
+          extensions.push({
+            name: 'PausableConfig',
+            details: extensionDetails,
+          });
+          break;
+
+        case 'ScaledUiAmountConfig':
+          extensionDetails.authority = ext.authority ? ext.authority : null;
+          extensionDetails.multiplier = ext.multiplier;
+          extensions.push({
+            name: 'ScaledUiAmountConfig',
+            details: extensionDetails,
+          });
+          scaledUiAmount = {
+            enabled: true,
+            multiplier: ext.multiplier,
+            authority: authorities.metadataAuthority,
+          };
+          break;
+
+        case 'TransferFeeConfig':
+          if (ext.transferFeeConfigAuthority) {
+            extensionDetails.authority = ext.transferFeeConfigAuthority;
+          }
+          if (ext.withdrawWithheldAuthority) {
+            extensionDetails.withdrawAuthority = ext.withdrawWithheldAuthority;
+          }
+          extensions.push({
+            name: 'TransferFeeConfig',
+            details: extensionDetails,
+          });
+          break;
+
+        case 'MetadataPointer':
+          extensionDetails.authority =
+            ext.authority?.__option === 'Some' ? ext.authority.value : null;
+          extensionDetails.metadataAddress =
+            ext.metadataAddress?.__option === 'Some'
+              ? ext.metadataAddress.value
+              : null;
+          extensions.push({
+            name: 'MetadataPointer',
+            details: extensionDetails,
+          });
+          break;
+
+        default:
+          // Add any other extension generically
+          extensions.push({
+            name: ext.__kind,
+            details: { ...ext },
+          });
+      }
+    }
+
+    // Check for SRFC37 and ScaledUiAmount in additional metadata
+    enableSrfc37 = authorities.freezeAuthority === TOKEN_ACL_PROGRAM_ID;
+  }
+
+  // For legacy SPL tokens, try to fetch Metaplex metadata
+  if (!isToken2022 && !metadata) {
+    const metaplexMetadata = await fetchMetaplexMetadata(rpc, mintAddress);
+    if (metaplexMetadata) {
+      metadata = metaplexMetadata;
+      // For legacy tokens with metadata, add a virtual extension for tracking
+      extensions.push({
+        name: 'MetaplexMetadata',
+        details: { ...metaplexMetadata },
+      });
+    }
+  }
+
+  // Check if token is pausable (has freeze authority or PausableConfig)
+  isPausable = isPausable || authorities.freezeAuthority !== null;
+
+  // If pausable but no specific pausable authority, use freeze authority
+  if (isPausable && !authorities.pausableAuthority) {
+    authorities.pausableAuthority = authorities.freezeAuthority;
+  }
+
+  // Add Pausable to extensions if applicable
+  if (isPausable && !extensions.some(ext => ext.name === 'Pausable')) {
+    extensions.push({ name: 'Pausable' });
+  }
+
+  // Detect token type
+  const detectedType = detectTokenType(extensions);
+
+  return {
+    address: mintAddress,
+    programId: encodedAccount.programAddress,
+    supplyInfo,
+    metadata,
+    authorities,
+    extensions,
+    detectedType,
+    isPausable,
+    isToken2022,
+    aclMode,
+    enableSrfc37,
+    scaledUiAmount,
+  };
+}
+
+function detectTokenType(extensions: TokenExtension[]): TokenType {
+  const extensionNames = extensions.map(ext => ext.name);
+
+  // Check for tokenized security pattern (includes ScaledUiAmount)
+  const isTokenizedSecurity = TOKENIZED_SECURITY_EXTENSIONS.every(ext =>
+    extensionNames.includes(ext)
+  );
+
+  if (isTokenizedSecurity) {
+    return 'tokenized-security';
+  }
+
+  // Check for stablecoin pattern
+  const isStablecoin = STABLECOIN_EXTENSIONS.every(ext =>
+    extensionNames.includes(ext)
+  );
+
+  if (isStablecoin) {
+    return 'stablecoin';
+  }
+
+  // Check for arcade token pattern
+  const isArcadeToken =
+    ARCADE_TOKEN_EXTENSIONS.every(ext => extensionNames.includes(ext)) &&
+    !extensionNames.includes('ConfidentialTransferMint') &&
+    !extensionNames.includes('ScaledUiAmount');
+
+  if (isArcadeToken) {
+    return 'arcade-token';
+  }
+
+  return 'unknown';
+}
+
+export async function getTokenMetadata(
+  rpc: Rpc<SolanaRpcApi>,
+  mintAddress: Address
+): Promise<TokenMetadata | null> {
+  const inspection = await inspectToken(rpc, mintAddress);
+  return inspection.metadata || null;
+}
+
+export async function getTokenExtensionsDetailed(
+  rpc: Rpc<SolanaRpcApi>,
+  mintAddress: Address
+): Promise<TokenExtension[]> {
+  const inspection = await inspectToken(rpc, mintAddress);
+  return inspection.extensions;
+}
+
+export async function detectTokenTypeFromMint(
+  rpc: Rpc<SolanaRpcApi>,
+  mintAddress: Address
+): Promise<TokenType> {
+  const inspection = await inspectToken(rpc, mintAddress);
+  return inspection.detectedType;
+}
+
+// Helper function to convert inspection result to dashboard data format
+export function inspectionResultToDashboardData(
+  inspection: TokenInspectionResult
+): TokenDashboardData {
+  const {
+    address,
+    supplyInfo,
+    metadata,
+    authorities,
+    extensions,
+    detectedType,
+    aclMode,
+    enableSrfc37,
+    scaledUiAmount,
+  } = inspection;
+
+  return {
+    // Basic token info
+    name: metadata?.name || '',
+    symbol: metadata?.symbol || '',
+    address: address.toString(),
+    decimals: supplyInfo.decimals,
+    supply: supplyInfo.supply.toString(),
+    uri: metadata?.uri,
+    type: detectedType,
+
+    // ACL configuration
+    aclMode,
+    enableSrfc37,
+
+    // All authorities as strings
+    mintAuthority: authorities.mintAuthority?.toString(),
+    metadataAuthority: authorities.metadataAuthority?.toString(),
+    pausableAuthority: authorities.pausableAuthority?.toString(),
+    confidentialBalancesAuthority:
+      authorities.confidentialBalancesAuthority?.toString(),
+    permanentDelegateAuthority:
+      authorities.permanentDelegateAuthority?.toString(),
+    scaledUiAmountAuthority: authorities.scaledUiAmountAuthority?.toString(),
+    freezeAuthority: authorities.freezeAuthority?.toString(),
+
+    // Extensions list
+    extensions: extensions.map(ext => ext.name),
+
+    // Scaled UI amount multiplier (for tokenized securities)
+    multiplier: scaledUiAmount?.multiplier,
+  };
+}
+
+// Convenience function to get complete token info for dashboard
+export async function getTokenDashboardData(
+  rpc: Rpc<SolanaRpcApi>,
+  mintAddress: Address
+): Promise<TokenDashboardData> {
+  const inspection = await inspectToken(rpc, mintAddress);
+  return inspectionResultToDashboardData(inspection);
+}

--- a/packages/sdk/src/inspection/types.ts
+++ b/packages/sdk/src/inspection/types.ts
@@ -1,0 +1,103 @@
+import type { Address } from 'gill';
+
+export interface TokenMetadata {
+  name?: string;
+  symbol?: string;
+  uri?: string;
+  decimals?: number;
+  updateAuthority?: Address | null;
+  additionalMetadata?: Map<string, string>;
+}
+
+export interface TokenAuthorities {
+  mintAuthority?: Address | null;
+  freezeAuthority?: Address | null;
+  updateAuthority?: Address | null;
+  permanentDelegate?: Address | null;
+  permanentDelegateAuthority?: Address | null;
+  metadataAuthority?: Address | null;
+  pausableAuthority?: Address | null;
+  confidentialBalancesAuthority?: Address | null;
+  scaledUiAmountAuthority?: Address | null;
+}
+
+export interface TokenSupplyInfo {
+  supply: bigint;
+  decimals: number;
+  isInitialized: boolean;
+}
+
+export interface TokenExtension {
+  name: string;
+  details?: Record<string, any>;
+}
+
+export type TokenType =
+  | 'stablecoin'
+  | 'arcade-token'
+  | 'tokenized-security'
+  | 'unknown';
+
+export type AclMode = 'allowlist' | 'blocklist' | 'none';
+
+export interface ScaledUiAmountInfo {
+  enabled: boolean;
+  multiplier?: number;
+  authority?: Address | null;
+}
+
+export interface TokenInspectionResult {
+  // Basic info
+  address: Address;
+  programId: Address;
+  supplyInfo: TokenSupplyInfo;
+
+  // Metadata
+  metadata?: TokenMetadata;
+
+  // All authorities
+  authorities: TokenAuthorities;
+
+  // Extensions and features
+  extensions: TokenExtension[];
+  detectedType: TokenType;
+  isPausable: boolean;
+  isToken2022: boolean;
+
+  // ACL/SRFC37 info
+  aclMode: AclMode;
+  enableSrfc37: boolean;
+
+  // Scaled UI amount info (for tokenized securities)
+  scaledUiAmount?: ScaledUiAmountInfo;
+}
+
+export interface TokenDashboardData {
+  // Basic token info
+  name: string;
+  symbol: string;
+  address: string;
+  decimals: number;
+  supply: string;
+  uri?: string;
+  type: TokenType;
+
+  // ACL configuration
+  aclMode: AclMode;
+  enableSrfc37: boolean;
+
+  // All authorities as strings
+  mintAuthority?: string;
+  metadataAuthority?: string;
+  pausableAuthority?: string;
+  confidentialBalancesAuthority?: string;
+  permanentDelegateAuthority?: string;
+  scaledUiAmountAuthority?: string;
+  freezeAuthority?: string;
+
+  // Extensions list
+  extensions: string[];
+
+  // Scaled UI amount multiplier (for tokenized securities)
+  multiplier?: number;
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@mosaic/sdk": "workspace:*",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@solana/accounts": "^2.3.0",
     "@solana/react": "^2.3.0",

--- a/packages/ui/src/app/dashboard/create/page.tsx
+++ b/packages/ui/src/app/dashboard/create/page.tsx
@@ -7,7 +7,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { DollarSign, Gamepad2, CandlestickChart } from 'lucide-react';
+import { DollarSign, Gamepad2, CandlestickChart, Upload } from 'lucide-react';
 import Link from 'next/link';
 
 export default function CreatePage() {
@@ -68,6 +68,23 @@ export default function CreatePage() {
                 <CardDescription>
                   Create a compliant security token with scaled UI amounts and
                   core controls.
+                </CardDescription>
+              </CardContent>
+            </Card>
+          </Link>
+
+          <Link href="/dashboard/import" className="block">
+            <Card className="h-full flex flex-col cursor-pointer hover:shadow-lg transition-shadow">
+              <CardHeader>
+                <div className="flex items-center">
+                  <Upload className="h-8 w-8 text-primary mr-3" />
+                  <CardTitle>Import Existing Token</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent className="flex-1">
+                <CardDescription>
+                  Import an existing token to manage it through the Mosaic
+                  platform.
                 </CardDescription>
               </CardContent>
             </Card>

--- a/packages/ui/src/app/dashboard/import/page.tsx
+++ b/packages/ui/src/app/dashboard/import/page.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useState, useContext } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { ArrowLeft, Upload, AlertCircle, CheckCircle2 } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { RpcContext } from '@/context/RpcContext';
+import { getTokenDashboardData } from '@mosaic/sdk';
+import { TokenStorage } from '@/lib/token/tokenStorage';
+import { TokenDisplay } from '@/types/token';
+import { Loader } from '@/components/ui/loader';
+import { address } from 'gill';
+
+export default function ImportTokenPage() {
+  const router = useRouter();
+  const { rpc } = useContext(RpcContext);
+  const [tokenAddress, setTokenAddress] = useState('');
+  const [tokenType, setTokenType] = useState('none');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const [importedTokenInfo, setImportedTokenInfo] = useState<{
+    name: string;
+    symbol: string;
+    type: string;
+    isLegacy: boolean;
+  } | null>(null);
+
+  const handleImport = async () => {
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      // Validate address format
+      if (!tokenAddress || tokenAddress.length < 32) {
+        throw new Error('Please enter a valid Solana token address');
+      }
+
+      // Convert string to Address type
+      let mintAddress;
+      try {
+        mintAddress = address(tokenAddress);
+      } catch {
+        throw new Error('Invalid Solana address format');
+      }
+
+      // Fetch token data from blockchain
+      const tokenData = await getTokenDashboardData(rpc as any, mintAddress);
+
+      // Override type if user selected one
+      if (tokenType !== 'none') {
+        tokenData.type = tokenType as any;
+      }
+
+      // Check if this is a legacy token (no extensions or only MetaplexMetadata)
+      const isLegacyToken =
+        !tokenData.extensions ||
+        tokenData.extensions.length === 0 ||
+        (tokenData.extensions.length === 1 &&
+          tokenData.extensions[0] === 'MetaplexMetadata') ||
+        (tokenData.extensions.length === 2 &&
+          tokenData.extensions.includes('MetaplexMetadata') &&
+          tokenData.extensions.includes('Pausable'));
+
+      if (isLegacyToken) {
+        console.log('Imported legacy SPL token with Metaplex metadata');
+      }
+
+      // Convert to TokenDisplay format for storage
+      const tokenDisplay: TokenDisplay = {
+        name: tokenData.name || 'Unknown Token',
+        symbol: tokenData.symbol || 'UNKNOWN',
+        address: tokenData.address,
+        type: tokenData.type === 'unknown' ? undefined : tokenData.type,
+        decimals: tokenData.decimals,
+        supply: tokenData.supply,
+        mintAuthority: tokenData.mintAuthority,
+        metadataAuthority: tokenData.metadataAuthority,
+        pausableAuthority: tokenData.pausableAuthority,
+        confidentialBalancesAuthority: tokenData.confidentialBalancesAuthority,
+        permanentDelegateAuthority: tokenData.permanentDelegateAuthority,
+        scaledUiAmountAuthority: tokenData.scaledUiAmountAuthority,
+        freezeAuthority: tokenData.freezeAuthority,
+        extensions: tokenData.extensions,
+        metadataUri: tokenData.uri,
+        createdAt: new Date().toISOString(),
+      };
+
+      // Check if token already exists
+      const existingToken = TokenStorage.findTokenByAddress(tokenData.address);
+      if (existingToken) {
+        const confirmUpdate = window.confirm(
+          'This token already exists in your dashboard. Do you want to update it with the latest information?'
+        );
+        if (!confirmUpdate) {
+          setIsLoading(false);
+          return;
+        }
+      }
+
+      // Save to local storage
+      TokenStorage.saveToken(tokenDisplay);
+
+      // Store info for success message
+      setImportedTokenInfo({
+        name: tokenDisplay.name || '',
+        symbol: tokenDisplay.symbol || '',
+        type: tokenDisplay.type || tokenData.type,
+        isLegacy: isLegacyToken,
+      });
+
+      setSuccess(true);
+
+      // Redirect to dashboard after a short delay
+      setTimeout(() => {
+        router.push('/dashboard');
+      }, 2000);
+    } catch (err) {
+      console.error('Error importing token:', err);
+
+      // Provide user-friendly error messages
+      let errorMessage = 'Failed to import token. ';
+
+      if (err instanceof Error) {
+        if (err.message.includes('not found')) {
+          errorMessage += 'Token not found at the specified address.';
+        } else if (err.message.includes('Invalid mint account')) {
+          errorMessage += 'The address does not belong to a valid token mint.';
+        } else if (err.message.includes('Token-2022')) {
+          errorMessage +=
+            'This appears to be a legacy SPL token. Import functionality is optimized for Token-2022 tokens.';
+        } else {
+          errorMessage += err.message;
+        }
+      } else {
+        errorMessage += 'Please check the address and try again.';
+      }
+
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex-1 p-8">
+      <div className="max-w-2xl mx-auto">
+        <Link href="/dashboard/create">
+          <Button variant="ghost" className="mb-6">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Back to Create
+          </Button>
+        </Link>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Import Existing Token</CardTitle>
+            <CardDescription>
+              Enter the address of an existing token to import it into the
+              Mosaic platform
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-2">
+              <Label htmlFor="token-address">Token Address</Label>
+              <Input
+                id="token-address"
+                type="text"
+                placeholder="Enter token mint address..."
+                value={tokenAddress}
+                onChange={e => setTokenAddress(e.target.value.trim())}
+                disabled={isLoading || success}
+              />
+              <p className="text-sm text-muted-foreground">
+                The Solana address of the token mint you want to import
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="token-type">Token Type (Optional)</Label>
+              <Select
+                value={tokenType}
+                onValueChange={setTokenType}
+                disabled={isLoading || success}
+              >
+                <SelectTrigger id="token-type">
+                  <SelectValue placeholder="Select a token type" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">None / N/A</SelectItem>
+                  <SelectItem value="stablecoin">Stablecoin</SelectItem>
+                  <SelectItem value="arcade-token">Arcade Token</SelectItem>
+                  <SelectItem value="tokenized-security">
+                    Tokenized Security
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-sm text-muted-foreground">
+                Optionally categorize this token for better organization
+              </p>
+            </div>
+
+            {error && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+
+            {success && importedTokenInfo && (
+              <Alert className="border-green-500 bg-green-50 dark:bg-green-950/20">
+                <CheckCircle2 className="h-4 w-4 text-green-600" />
+                <AlertDescription className="text-green-600 dark:text-green-400">
+                  Successfully imported {importedTokenInfo.name} (
+                  {importedTokenInfo.symbol})
+                  {importedTokenInfo.type !== 'unknown' &&
+                    ` as ${importedTokenInfo.type}`}
+                  {importedTokenInfo.isLegacy && ' - Legacy SPL Token'}.
+                  Redirecting to dashboard...
+                </AlertDescription>
+              </Alert>
+            )}
+
+            <div className="flex gap-4">
+              <Button
+                className="flex-1"
+                disabled={!tokenAddress || isLoading || success}
+                onClick={handleImport}
+              >
+                {isLoading ? (
+                  <>
+                    <Loader className="h-4 w-4 mr-2" />
+                    Importing...
+                  </>
+                ) : success ? (
+                  <>
+                    <CheckCircle2 className="h-4 w-4 mr-2" />
+                    Imported!
+                  </>
+                ) : (
+                  <>
+                    <Upload className="h-4 w-4 mr-2" />
+                    Import Token
+                  </>
+                )}
+              </Button>
+              <Link href="/dashboard/create" className="flex-1">
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  disabled={isLoading}
+                >
+                  Cancel
+                </Button>
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/app/dashboard/page.tsx
+++ b/packages/ui/src/app/dashboard/page.tsx
@@ -2,7 +2,7 @@
 
 import { useContext, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { Plus, Coins } from 'lucide-react';
+import { Plus, Coins, Upload } from 'lucide-react';
 import Link from 'next/link';
 import {
   Card,
@@ -178,6 +178,12 @@ function DashboardConnected({ publicKey }: { publicKey: string }) {
                 <Link href="/dashboard/create/tokenized-security">
                   <Coins className="h-4 w-4 mr-2" />
                   Tokenized Security
+                </Link>
+              </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/dashboard/import">
+                  <Upload className="h-4 w-4 mr-2" />
+                  Import Existing Token
                 </Link>
               </DropdownMenuItem>
             </DropdownMenuContent>

--- a/packages/ui/src/components/ui/alert.tsx
+++ b/packages/ui/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/packages/ui/src/lib/solana/rpc.ts
+++ b/packages/ui/src/lib/solana/rpc.ts
@@ -76,7 +76,6 @@ export async function getTokenAuthorities(
       decodedMint.data.extensions.__option === 'Some'
     ) {
       for (const ext of decodedMint.data.extensions.value) {
-        console.log(ext);
         if (!ext.__kind) continue;
 
         switch (ext.__kind) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,15 +66,15 @@ importers:
       '@mosaic/abl':
         specifier: workspace:*
         version: link:../abl
-      '@mosaic/token-acl':
-        specifier: workspace:*
-        version: link:../token-acl
       '@mosaic/sdk':
         specifier: workspace:*
         version: link:../sdk
       '@mosaic/tlv-account-resolution':
         specifier: workspace:*
         version: link:../tlv-account-resolution
+      '@mosaic/token-acl':
+        specifier: workspace:*
+        version: link:../token-acl
       '@solana/accounts':
         specifier: ^2.3.0
         version: 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -116,51 +116,17 @@ importers:
         specifier: ^5.0.0
         version: 5.8.3
 
-  packages/token-acl:
-    dependencies:
-      '@mosaic/tlv-account-resolution':
-        specifier: workspace:*
-        version: link:../tlv-account-resolution
-      '@solana/kit':
-        specifier: 2.3.0
-        version: 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      gill:
-        specifier: ^0.10.2
-        version: 0.10.2(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      typescript:
-        specifier: ^5.0.0
-        version: 5.8.3
-    devDependencies:
-      '@types/jest':
-        specifier: ^29.5.0
-        version: 29.5.14
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.34.0
-        version: 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.32.0(jiti@1.21.7))(typescript@5.8.3)
-      '@typescript-eslint/parser':
-        specifier: ^8.34.0
-        version: 8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.8.3)
-      eslint:
-        specifier: ^9.32.0
-        version: 9.32.0(jiti@1.21.7)
-      jest:
-        specifier: ^29.5.0
-        version: 29.7.0(@types/node@20.19.9)
-      ts-jest:
-        specifier: ^29.1.0
-        version: 29.4.0(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.9))(typescript@5.8.3)
-
   packages/sdk:
     dependencies:
       '@mosaic/abl':
         specifier: workspace:*
         version: link:../abl
-      '@mosaic/token-acl':
-        specifier: workspace:*
-        version: link:../token-acl
       '@mosaic/tlv-account-resolution':
         specifier: workspace:*
         version: link:../tlv-account-resolution
+      '@mosaic/token-acl':
+        specifier: workspace:*
+        version: link:../token-acl
       gill:
         specifier: ^0.10.2
         version: 0.10.2(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -218,6 +184,40 @@ importers:
         specifier: ^29.1.0
         version: 29.4.0(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.9))(typescript@5.8.3)
 
+  packages/token-acl:
+    dependencies:
+      '@mosaic/tlv-account-resolution':
+        specifier: workspace:*
+        version: link:../tlv-account-resolution
+      '@solana/kit':
+        specifier: 2.3.0
+        version: 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      gill:
+        specifier: ^0.10.2
+        version: 0.10.2(@solana/sysvars@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.0
+        version: 29.5.14
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.34.0
+        version: 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.32.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.34.0
+        version: 8.38.0(eslint@9.32.0(jiti@1.21.7))(typescript@5.8.3)
+      eslint:
+        specifier: ^9.32.0
+        version: 9.32.0(jiti@1.21.7)
+      jest:
+        specifier: ^29.5.0
+        version: 29.7.0(@types/node@20.19.9)
+      ts-jest:
+        specifier: ^29.1.0
+        version: 29.4.0(@babel/core@7.28.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.9))(typescript@5.8.3)
+
   packages/ui:
     dependencies:
       '@mosaic/sdk':
@@ -226,6 +226,12 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.0.6
         version: 2.1.15(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.8
+        version: 1.3.8(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-select':
+        specifier: ^2.2.6
+        version: 2.2.6(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@18.3.23)(react@18.3.1)
@@ -1294,8 +1300,14 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
+
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
@@ -1363,6 +1375,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-dropdown-menu@2.1.15':
     resolution: {integrity: sha512-mIBnOjgwo9AH3FyKaSWoSu/dYj6VdhJ7frEPiGTeXCdUFHjl9h3mFh2wwhEtINOmYXWhdpf1rY2minFsmaNgVQ==}
     peerDependencies:
@@ -1378,6 +1403,15 @@ packages:
 
   '@radix-ui/react-focus-guards@1.1.2':
     resolution: {integrity: sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1433,6 +1467,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
@@ -1459,6 +1506,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
     peerDependencies:
@@ -1472,8 +1532,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.10':
     resolution: {integrity: sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1539,6 +1638,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-rect@1.1.1':
     resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
     peerDependencies:
@@ -1555,6 +1663,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/rect@1.1.1':
@@ -7618,7 +7739,11 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@radix-ui/number@1.1.1': {}
+
   '@radix-ui/primitive@1.1.2': {}
+
+  '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -7672,6 +7797,19 @@ snapshots:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
+
   '@radix-ui/react-dropdown-menu@2.1.15(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.2
@@ -7688,6 +7826,12 @@ snapshots:
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
   '@radix-ui/react-focus-guards@1.1.2(@types/react@18.3.23)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.23
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
@@ -7755,6 +7899,24 @@ snapshots:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7775,9 +7937,37 @@ snapshots:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
+
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.23)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -7797,6 +7987,52 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
+
+  '@radix-ui/react-select@2.2.6(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.1(@types/react@18.3.23)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.23
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
@@ -7842,6 +8078,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.23
 
+  '@radix-ui/react-use-previous@1.1.1(@types/react@18.3.23)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.23
+
   '@radix-ui/react-use-rect@1.1.1(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
       '@radix-ui/rect': 1.1.1
@@ -7855,6 +8097,15 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.23
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
   '@radix-ui/rect@1.1.1': {}
 


### PR DESCRIPTION
# PR: Add Token Import Functionality

## Summary

Adds the ability to import existing Solana tokens (Token-2022 and legacy SPL) into the Mosaic dashboard for management.

## What's New

### Features
• New Import Page (/dashboard/import) - Import tokens by entering their mint address
• Auto-detection - Automatically identifies token type (stablecoin, arcade token, etc.) based on extensions
• Legacy Support - Works with both Token-2022 and legacy SPL tokens with Metaplex metadata
• Smart Detection - Extracts all token data including name, symbol, authorities, and extensions

### Technical Changes
• SDK Enhancement - New inspection module in @mosaic/sdk
 • inspectToken() - Fetches comprehensive token information
 • getTokenDashboardData() - Returns dashboard-ready token data
 • Metaplex metadata parsing for legacy tokens
• UI Integration - Import flow with validation, loading states, and error handling
• Local Storage - Seamlessly saves imported tokens for dashboard display

### Key Files
packages/sdk/src/inspection/  # Token inspection logic
packages/ui/src/app/dashboard/import/  # Import UI

## Usage
1. Navigate to Dashboard → Create New Token → Import Existing Token
2. Enter token mint address
3. Optionally select token type
4. Click Import

## Testing
• ✅ Token-2022 with extensions
• ✅ Legacy SPL tokens with Metaplex metadata
• ✅ Error handling for invalid addresses
• ✅ TypeScript compilation passes

No breaking changes. Ready for review.